### PR TITLE
Fix: Remove hardcoded password from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ This project, "Lynda Library Project", is designed for library data analysis and
 ### Database Setup
 1.  Ensure you have a MySQL server running.
 2.  Create a database named `library`.
-3.  The necessary tables (`books`, `patrons`, `loans`) and their schema can be inferred from the queries in `Lynda Library Proejct.sql` and the data interaction in `Lynda Library Proejct.ipynb`. You will need to create these tables and populate them with your library data. The notebook connects using `host = "localhost", username="root", password="MINA@123456789", database = "library", port=3306`. You may need to adjust these connection parameters.
+3.  The necessary tables (`books`, `patrons`, `loans`) and their schema can be inferred from the queries in `Lynda Library Proejct.sql` and the data interaction in `Lynda Library Proejct.ipynb`. You will need to create these tables and populate them with your library data. The notebook connects to the database using parameters like host, username, password, database name, and port. An example connection string used in the notebook is `host = "localhost", username="root", database = "library", port=3306`. You will need to provide your own credentials.
+
+**Important Security Note:** It is strongly recommended *not* to hardcode your database password directly in the notebook or any script. Instead, use secure methods like environment variables, a configuration file that is not committed to version control, or a secrets management system to handle your database credentials.
 
 ### Running the Notebook
 1.  Update the database connection details in the second cell of the `Lynda Library Proejct.ipynb` notebook if they differ from your setup.


### PR DESCRIPTION
### **User description**
I removed the example database password from the README.md file to enhance security. I also added a recommendation to use environment variables or a configuration file for managing database credentials securely.


___

### **PR Type**
Documentation


___

### **Description**
- Removed hardcoded database password from README example.

- Added security recommendation for handling credentials.

- Updated database connection instructions for clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Remove password and add security advice in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Removed the example database password from connection instructions.<br> <li> Clarified connection string usage without exposing credentials.<br> <li> Added a security note recommending secure credential management.


</details>


  </td>
  <td><a href="https://github.com/MinaTharwat93/Lynda-Library---SQL/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>